### PR TITLE
[Security Fix] Check directory existence

### DIFF
--- a/plugin/synctermcwd.vim
+++ b/plugin/synctermcwd.vim
@@ -10,7 +10,13 @@ set cpo&vim
 
 function! Tapi_SyncTermCwd(_, cwd) abort
   let cd = get(g:, 'synctermcwd_cd_command', 'SyncTermCwdConditionalCd')
-  execute cd a:cwd
+  if isdirectory(a:cwd)
+    execute cd a:cwd
+  else
+    echohl ErrorMsg
+    echomsg 'sync-term-cwd: No such directory:' a:cwd
+    echohl None
+  endif
 endfunction
 
 command! -nargs=1 -complete=dir SyncTermCwdConditionalCd call s:conditional_cd(<q-args>)


### PR DESCRIPTION
This fixes #1

## Before

This command shows `ls` command output.

```vim
:call Tapi_SyncTermCwd(1, '|echo system("ls")')
```

## After

Above command outputs an error message (don't execute `ls` command).

```
sync-term-cwd: No such directory: |echo system("ls")
```