### PR TITLE
fix Tapi_SyncTermCwd() for paths like "foo/#bar"

### DIFF
--- a/plugin/synctermcwd.vim
+++ b/plugin/synctermcwd.vim
@@ -13,7 +13,7 @@ let $SYNCTERMCWD_LOADED = 'true'
 function! Tapi_SyncTermCwd(_, cwd) abort
   let cd = get(g:, 'synctermcwd_cd_command', 'SyncTermCwdConditionalCd')
   if isdirectory(a:cwd)
-    execute cd a:cwd
+    execute cd fnameescape(a:cwd)
   else
     echohl ErrorMsg
     echomsg 'sync-term-cwd: No such directory:' a:cwd


### PR DESCRIPTION
I have a problem, that is

terminal output

```console
$ cd path/included/#foo
```

Vim's output
```
E194: '#'を置き換える副ファイルの名前がありません: lcd path/included/#foo
```

This PR fixes it.

Thanks :D